### PR TITLE
feat: 🎸 Functional Middleware

### DIFF
--- a/pkg/middleware/middleware_test.go
+++ b/pkg/middleware/middleware_test.go
@@ -9,20 +9,26 @@ import (
 	"github.com/bradcypert/ghast/pkg/router"
 )
 
+type MiddlewareKey int
+
+const (
+	KEY MiddlewareKey = iota
+)
+
 func TestContextPassing(t *testing.T) {
 	t.Run("should be able to get path variables", func(t *testing.T) {
 		router := router.Router{}
 		var contextVal string
 
 		router.Get("/:name", func(w http.ResponseWriter, r *http.Request) {
-			contextVal = r.Context().Value("FOO").(string)
+			contextVal = r.Context().Value(KEY).(string)
 		})
 
 		router.AddMiddleware([]func(next http.Handler) http.Handler{
 			func(next http.Handler) http.Handler {
 				return http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
 					curContext := req.Context()
-					req = req.Clone(context.WithValue(curContext, "FOO", "BAR"))
+					req = req.Clone(context.WithValue(curContext, KEY, "BAR"))
 
 					next.ServeHTTP(w, req)
 				})

--- a/pkg/middleware/middleware_test.go
+++ b/pkg/middleware/middleware_test.go
@@ -1,0 +1,40 @@
+package middleware
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/bradcypert/ghast/pkg/router"
+)
+
+func TestContextPassing(t *testing.T) {
+	t.Run("should be able to get path variables", func(t *testing.T) {
+		router := router.Router{}
+		var contextVal string
+
+		router.Get("/:name", func(w http.ResponseWriter, r *http.Request) {
+			contextVal = r.Context().Value("FOO").(string)
+		})
+
+		router.AddMiddleware([]func(next http.Handler) http.Handler{
+			func(next http.Handler) http.Handler {
+				return http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
+					curContext := req.Context()
+					req = req.Clone(context.WithValue(curContext, "FOO", "BAR"))
+
+					next.ServeHTTP(w, req)
+				})
+			},
+		})
+
+		server := router.DefaultServer()
+		req := httptest.NewRequest(http.MethodGet, "/foo", nil)
+		resp := httptest.NewRecorder()
+		server.Handler.ServeHTTP(resp, req)
+		if contextVal != "BAR" {
+			t.Error("Failed to set context as part of middleware chain")
+		}
+	})
+}

--- a/pkg/router/router.go
+++ b/pkg/router/router.go
@@ -21,7 +21,15 @@ const (
 	trace   string = "TRACE"
 )
 
-// MiddlewareFunc is a functional alias to signify the signature of a middleware anonymous function.
+// MiddlewareFunc type alias for a function that takes in a http.Handler and returns an HTTP Handler
+//	func(next http.Handler) http.Handler {
+//		return http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
+//			curContext := req.Context()
+//			req = req.Clone(context.WithValue(curContext, KEY, "BAR"))
+//
+//			next.ServeHTTP(w, req)
+//		})
+//  }
 type MiddlewareFunc = func(next http.Handler) http.Handler
 
 // Binding maps a url pattern to an HTTP handler

--- a/pkg/router/router.go
+++ b/pkg/router/router.go
@@ -22,11 +22,11 @@ const (
 )
 
 // MiddlewareFunc is a functional alias to signify the signature of a middleware anonymous function.
-type MiddlewareFunc = func(*http.ResponseWriter, *http.Request)
+type MiddlewareFunc = func(next http.Handler) http.Handler
 
 // Binding maps a url pattern to an HTTP handler
 type Binding struct {
-	handler     func(http.ResponseWriter, *http.Request)
+	handler     http.Handler
 	match       string
 	method      string
 	middlewares []MiddlewareFunc
@@ -89,16 +89,6 @@ func (r Router) ServeHTTP(rw http.ResponseWriter, req *http.Request) {
 
 			if match != nil {
 
-				// Run global middlewares
-				for _, m := range r.middlewares {
-					m(&rw, req)
-				}
-
-				// Run route specific middlewares
-				for _, m := range binding.middlewares {
-					m(&rw, req)
-				}
-
 				ctx := req.Context()
 				for _, g := range match.Groups() {
 					if len(tokens) >= match.Index && len(tokens) > 0 {
@@ -108,8 +98,18 @@ func (r Router) ServeHTTP(rw http.ResponseWriter, req *http.Request) {
 					}
 				}
 
-				r := req.WithContext(ctx)
-				binding.handler(rw, r)
+				req := req.Clone(ctx)
+
+				allMiddlewares := append([]MiddlewareFunc{}, binding.middlewares...)
+				allMiddlewares = append(allMiddlewares, r.middlewares...)
+
+				handler := binding.handler
+
+				for _, m := range allMiddlewares {
+					handler = m(handler)
+				}
+
+				handler.ServeHTTP(rw, req)
 				break
 			}
 		}


### PR DESCRIPTION
Originally our middleware was able to introspect the request chain, but
could not actually send data to future middlewares or modify the
incoming request chain (still cant, but now you can achieve the same
results as if you could). These changes introduce a new composable
middleware pattern while still supporting the same-ish interface at the
router level. These interfaces are far more predictable and dont seem to
have weird side effects.

BREAKING CHANGE: 🧨 Router middleware will need to be modified to support this new pattern