### PR TITLE
feat: 🎸 Redesigned Controller Interface

### DIFF
--- a/cmd/new.go
+++ b/cmd/new.go
@@ -127,5 +127,5 @@ var demoControllerTemplate string
 //go:embed view.tmpl
 var viewTemplate string
 
-//go:embed yaml.tmpl
+//go:embed main.tmpl
 var mainTemplate string

--- a/pkg/controllers/controller.go
+++ b/pkg/controllers/controller.go
@@ -1,6 +1,8 @@
 package controllers
 
 import (
+	"bufio"
+	"bytes"
 	"encoding/json"
 	"io/ioutil"
 	"net/http"
@@ -56,13 +58,21 @@ func (c GhastController) Unmarshal(r *http.Request, s interface{}) error {
 }
 
 // View executes a view from the app templates
-func (c GhastController) View(name string, w http.ResponseWriter, vars jet.VarMap, contextualData interface{}) {
+// returns a response with the body set to the template
+// Feel free to modify the response object further before returning
+// in your controller
+func (c GhastController) View(name string, vars jet.VarMap, contextualData interface{}) (Response, error) {
 	tmpl, err := ghastApp.GetApp(c.Container()).GetViewSet().GetTemplate(name)
 	if err != nil {
-		w.WriteHeader(http.StatusInternalServerError)
+		return Response{}, err
 	}
 
-	if err = tmpl.Execute(w, vars, contextualData); err != nil {
-		w.WriteHeader(http.StatusInternalServerError)
-	}
+	var b bytes.Buffer
+	writer := bufio.NewWriter(&b)
+
+	err = tmpl.Execute(writer, vars, contextualData)
+
+	return Response{
+		Body: b.Bytes(),
+	}, err
 }

--- a/pkg/controllers/controller.go
+++ b/pkg/controllers/controller.go
@@ -10,6 +10,7 @@ import (
 	"github.com/CloudyKit/jet"
 	ghastApp "github.com/bradcypert/ghast/pkg/app"
 	ghastContainer "github.com/bradcypert/ghast/pkg/container"
+	"github.com/bradcypert/ghast/pkg/router"
 )
 
 // GhastController should be embedded into consumer controllers
@@ -61,10 +62,10 @@ func (c GhastController) Unmarshal(r *http.Request, s interface{}) error {
 // returns a response with the body set to the template
 // Feel free to modify the response object further before returning
 // in your controller
-func (c GhastController) View(name string, vars jet.VarMap, contextualData interface{}) (Response, error) {
+func (c GhastController) View(name string, vars jet.VarMap, contextualData interface{}) (router.Response, error) {
 	tmpl, err := ghastApp.GetApp(c.Container()).GetViewSet().GetTemplate(name)
 	if err != nil {
-		return Response{}, err
+		return router.Response{}, err
 	}
 
 	var b bytes.Buffer
@@ -72,7 +73,7 @@ func (c GhastController) View(name string, vars jet.VarMap, contextualData inter
 
 	err = tmpl.Execute(writer, vars, contextualData)
 
-	return Response{
+	return router.Response{
 		Body: b.Bytes(),
 	}, err
 }

--- a/pkg/controllers/controller_test.go
+++ b/pkg/controllers/controller_test.go
@@ -86,8 +86,8 @@ type MockController struct {
 	GhastController
 }
 
-func (m MockController) Get(req *http.Request) (Response, error) {
-	return Response{
+func (m MockController) Get(req *http.Request) (router.Response, error) {
+	return router.Response{
 		Body: "hello world",
 	}, nil
 }
@@ -95,13 +95,13 @@ func (m MockController) Get(req *http.Request) (Response, error) {
 func TestRouterWorksWithControllers(t *testing.T) {
 
 	t.Run("should handle controller response functions properly", func(t *testing.T) {
-		router := router.Router{}
+		r := router.Router{}
 
 		controller := MockController{}
 
-		router.Get("/:name", RouteFunc(controller.Get))
+		r.Get("/:name", router.RouteFunc(controller.Get))
 
-		server := router.DefaultServer()
+		server := r.DefaultServer()
 		req := httptest.NewRequest(http.MethodGet, "/foo", nil)
 		resp := httptest.NewRecorder()
 		server.Handler.ServeHTTP(resp, req)

--- a/pkg/controllers/controller_test.go
+++ b/pkg/controllers/controller_test.go
@@ -106,7 +106,7 @@ func TestRouterWorksWithControllers(t *testing.T) {
 		resp := httptest.NewRecorder()
 		server.Handler.ServeHTTP(resp, req)
 		if resp.Body.String() != "hello world" {
-			t.Error("Failed to set name via context params, got {}", resp.Body)
+			t.Error("Failed to set name via context params, got ", resp.Body)
 		}
 	})
 

--- a/pkg/controllers/controller_test.go
+++ b/pkg/controllers/controller_test.go
@@ -3,6 +3,7 @@ package controllers
 import (
 	"bytes"
 	"encoding/json"
+	"fmt"
 	"net/http"
 	"net/http/httptest"
 	"testing"
@@ -86,10 +87,38 @@ type MockController struct {
 	GhastController
 }
 
+func (m MockController) Index(req *http.Request) (router.Response, error) {
+	return router.Response{
+		Body: "hello world",
+	}, nil
+}
+
 func (m MockController) Get(req *http.Request) (router.Response, error) {
 	return router.Response{
 		Body: "hello world",
 	}, nil
+}
+
+func (m MockController) Create(req *http.Request) (router.Response, error) {
+	return router.Response{
+		Body: "hello world",
+	}, nil
+}
+
+func (m MockController) Update(req *http.Request) (router.Response, error) {
+	return router.Response{
+		Body: "hello world",
+	}, nil
+}
+
+func (m MockController) Delete(req *http.Request) (router.Response, error) {
+	return router.Response{
+		Body: "hello world",
+	}, nil
+}
+
+func (m MockController) GetName() string {
+	return "mock"
 }
 
 func TestRouterWorksWithControllers(t *testing.T) {
@@ -109,5 +138,23 @@ func TestRouterWorksWithControllers(t *testing.T) {
 			t.Error("Failed to set name via context params, got ", resp.Body)
 		}
 	})
+}
 
+func TestResources(t *testing.T) {
+	t.Run("Resources should work", func(t *testing.T) {
+		r := router.Router{}
+
+		controller := MockController{}
+
+		r.Resource("/", controller)
+
+		server := r.DefaultServer()
+		req := httptest.NewRequest(http.MethodGet, "/mock", nil)
+		resp := httptest.NewRecorder()
+		server.Handler.ServeHTTP(resp, req)
+		fmt.Println(resp.Body.String())
+		if resp.Body.String() != "hello world" {
+			t.Error("Failed to set name via context params, got ", resp.Body)
+		}
+	})
 }

--- a/pkg/controllers/response.go
+++ b/pkg/controllers/response.go
@@ -1,0 +1,62 @@
+package controllers
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+)
+
+// Response a struct to define what a controller-based response looks like
+type Response struct {
+	Status  int
+	Body    interface{}
+	Headers http.Header
+	Length  int
+}
+
+// RouteFunc
+type RouteFunc func(req *http.Request) (Response, error)
+
+// ServeHTTP calls f(w, r).
+func (rf RouteFunc) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	// any error indicates an internal server error
+	// need to make sure this is surfaced and clear in the docs
+	response, err := rf(r)
+
+	// Int's default type is 0, lets roll this up to a success
+	if response.Status == 0 {
+		response.Status = 200
+	}
+
+	if err != nil {
+		w.WriteHeader(500)
+	}
+
+	// NEED TO FIGURE OUT HOW TO ADD HEADERS HERE
+	if response.Body != nil {
+		switch response.Body.(type) {
+		case string:
+			if err == nil {
+				w.WriteHeader(response.Status)
+			}
+			w.Write([]byte(response.Body.(string)))
+		case int:
+			if err == nil {
+				w.WriteHeader(response.Status)
+			}
+			w.Write([]byte(fmt.Sprint(response.Body.(int))))
+		default:
+			bytes, err := json.Marshal(response.Body)
+			if err != nil {
+				fmt.Println("ERR: Error when marshalling JSON passed from controller function")
+				w.WriteHeader(500)
+				w.Write(bytes)
+			} else {
+				if err == nil {
+					w.WriteHeader(response.Status)
+				}
+				w.Write(bytes)
+			}
+		}
+	}
+}

--- a/pkg/controllers/response.go
+++ b/pkg/controllers/response.go
@@ -37,6 +37,11 @@ func (rf RouteFunc) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	// NEED TO FIGURE OUT HOW TO ADD HEADERS HERE
 	if response.Body != nil {
 		switch response.Body.(type) {
+		case []byte:
+			if err == nil {
+				w.WriteHeader(response.Status)
+			}
+			w.Write(response.Body.([]byte))
 		case string:
 			if err == nil {
 				w.WriteHeader(response.Status)

--- a/pkg/controllers/response.go
+++ b/pkg/controllers/response.go
@@ -14,7 +14,9 @@ type Response struct {
 	Length  int
 }
 
-// RouteFunc
+// RouteFunc a type alias for controller actions
+// Controllers only hvae the request exposed to them as
+// the response writer is handled by the Ghast framework.
 type RouteFunc func(req *http.Request) (Response, error)
 
 // ServeHTTP calls f(w, r).

--- a/pkg/middleware/middleware_test.go
+++ b/pkg/middleware/middleware_test.go
@@ -20,9 +20,9 @@ func TestContextPassing(t *testing.T) {
 		router := router.Router{}
 		var contextVal string
 
-		router.Get("/:name", func(w http.ResponseWriter, r *http.Request) {
+		router.Get("/:name", http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 			contextVal = r.Context().Value(KEY).(string)
-		})
+		}))
 
 		router.AddMiddleware([]func(next http.Handler) http.Handler{
 			func(next http.Handler) http.Handler {

--- a/pkg/router/resource.go
+++ b/pkg/router/resource.go
@@ -7,9 +7,9 @@ import "net/http"
 // a single item, updating a single item, and deleting a single item
 type Resource interface {
 	GetName() string
-	Index(w http.ResponseWriter, r *http.Request)
-	Get(w http.ResponseWriter, r *http.Request)
-	Create(w http.ResponseWriter, r *http.Request)
-	Update(w http.ResponseWriter, r *http.Request)
-	Delete(w http.ResponseWriter, r *http.Request)
+	Index(req *http.Request) (Response, error)
+	Get(req *http.Request) (Response, error)
+	Create(req *http.Request) (Response, error)
+	Update(req *http.Request) (Response, error)
+	Delete(req *http.Request) (Response, error)
 }

--- a/pkg/router/response.go
+++ b/pkg/router/response.go
@@ -1,4 +1,4 @@
-package controllers
+package router
 
 import (
 	"encoding/json"
@@ -15,17 +15,17 @@ type Response struct {
 }
 
 // RouteFunc a type alias for controller actions
-// Controllers only hvae the request exposed to them as
+// Controllers only have the request exposed to them as
 // the response writer is handled by the Ghast framework.
 type RouteFunc func(req *http.Request) (Response, error)
 
-// ServeHTTP calls f(w, r).
+// ServeHTTP calls f(r).
 func (rf RouteFunc) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	// any error indicates an internal server error
 	// need to make sure this is surfaced and clear in the docs
 	response, err := rf(r)
 
-	// Int's default type is 0, lets roll this up to a success
+	// Int's type default is 0, lets roll this up to a success
 	if response.Status == 0 {
 		response.Status = 200
 	}

--- a/pkg/router/response.go
+++ b/pkg/router/response.go
@@ -53,8 +53,8 @@ func (rf RouteFunc) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 			}
 			w.Write([]byte(fmt.Sprint(response.Body.(int))))
 		default:
-			bytes, err := json.Marshal(response.Body)
-			if err != nil {
+			bytes, mErr := json.Marshal(response.Body)
+			if mErr != nil {
 				fmt.Println("ERR: Error when marshalling JSON passed from controller function")
 				w.WriteHeader(500)
 				w.Write(bytes)

--- a/pkg/router/router.go
+++ b/pkg/router/router.go
@@ -135,47 +135,47 @@ func (r *Router) QueryParam(req *http.Request, key string) interface{} {
 }
 
 // Get registers a new GET route with the router
-func (r *Router) Get(route string, f http.HandlerFunc, middleware ...MiddlewareFunc) *Router {
+func (r *Router) Get(route string, f http.Handler, middleware ...MiddlewareFunc) *Router {
 	return r.route(get, route, f, middleware)
 }
 
 // Post registers a new POST route with the router
-func (r *Router) Post(route string, f http.HandlerFunc, middleware ...MiddlewareFunc) *Router {
+func (r *Router) Post(route string, f http.Handler, middleware ...MiddlewareFunc) *Router {
 	return r.route(post, route, f, middleware)
 }
 
 // Put registeres a new PUT route with the router
-func (r *Router) Put(route string, f http.HandlerFunc, middleware ...MiddlewareFunc) *Router {
+func (r *Router) Put(route string, f http.Handler, middleware ...MiddlewareFunc) *Router {
 	return r.route(put, route, f, middleware)
 }
 
 // Patch registers a new PATCH route with the router
-func (r *Router) Patch(route string, f http.HandlerFunc, middleware ...MiddlewareFunc) *Router {
+func (r *Router) Patch(route string, f http.Handler, middleware ...MiddlewareFunc) *Router {
 	return r.route(patch, route, f, middleware)
 }
 
 // Delete registers a new DELETE route with the router
-func (r *Router) Delete(route string, f http.HandlerFunc, middleware ...MiddlewareFunc) *Router {
+func (r *Router) Delete(route string, f http.Handler, middleware ...MiddlewareFunc) *Router {
 	return r.route(delete, route, f, middleware)
 }
 
 // Options registers a new OPTIONS route with the router
-func (r *Router) Options(route string, f http.HandlerFunc, middleware ...MiddlewareFunc) *Router {
+func (r *Router) Options(route string, f http.Handler, middleware ...MiddlewareFunc) *Router {
 	return r.route(options, route, f, middleware)
 }
 
 // Head registers a new HEAD route with the router
-func (r *Router) Head(route string, f http.HandlerFunc, middleware ...MiddlewareFunc) *Router {
+func (r *Router) Head(route string, f http.Handler, middleware ...MiddlewareFunc) *Router {
 	return r.route(head, route, f, middleware)
 }
 
 // Trace registers a new TRACE route with the router
-func (r *Router) Trace(route string, f http.HandlerFunc, middleware ...MiddlewareFunc) *Router {
+func (r *Router) Trace(route string, f http.Handler, middleware ...MiddlewareFunc) *Router {
 	return r.route(trace, route, f, middleware)
 }
 
 // Connect registers a new CONNECT route with the router
-func (r *Router) Connect(route string, f http.HandlerFunc, middleware ...MiddlewareFunc) *Router {
+func (r *Router) Connect(route string, f http.Handler, middleware ...MiddlewareFunc) *Router {
 	return r.route(connect, route, f, middleware)
 }
 
@@ -190,11 +190,11 @@ func (r *Router) Connect(route string, f http.HandlerFunc, middleware ...Middlew
 // DELETE  /v1/user/:id
 // UPDATE /v1/user/:id
 func (r *Router) Resource(prefix string, resource Resource) {
-	r.Get(prefix+resource.GetName(), resource.Index)
-	r.Get(prefix+resource.GetName()+"/:id", resource.Get)
-	r.Post(prefix+resource.GetName(), resource.Create)
-	r.Delete(prefix+resource.GetName()+"/:id", resource.Delete)
-	r.Put(prefix+resource.GetName()+"/:id", resource.Update)
+	// r.Get(prefix+resource.GetName(), resource.Index)
+	// r.Get(prefix+resource.GetName()+"/:id", resource.Get)
+	// r.Post(prefix+resource.GetName(), resource.Create)
+	// r.Delete(prefix+resource.GetName()+"/:id", resource.Delete)
+	// r.Put(prefix+resource.GetName()+"/:id", resource.Update)
 }
 
 // DefaultServer is an optional method to help get a preconfigured server
@@ -209,7 +209,7 @@ func (r Router) DefaultServer() *http.Server {
 	}
 }
 
-func (r *Router) route(method string, route string, f http.HandlerFunc, middleware []MiddlewareFunc) *Router {
+func (r *Router) route(method string, route string, f http.Handler, middleware []MiddlewareFunc) *Router {
 	r.binding = append(r.binding, Binding{match: route, handler: f, middlewares: middleware, method: method})
 	return r
 }

--- a/pkg/router/router.go
+++ b/pkg/router/router.go
@@ -190,11 +190,11 @@ func (r *Router) Connect(route string, f http.Handler, middleware ...MiddlewareF
 // DELETE  /v1/user/:id
 // UPDATE /v1/user/:id
 func (r *Router) Resource(prefix string, resource Resource) {
-	// r.Get(prefix+resource.GetName(), resource.Index)
-	// r.Get(prefix+resource.GetName()+"/:id", resource.Get)
-	// r.Post(prefix+resource.GetName(), resource.Create)
-	// r.Delete(prefix+resource.GetName()+"/:id", resource.Delete)
-	// r.Put(prefix+resource.GetName()+"/:id", resource.Update)
+	r.Get(prefix+resource.GetName(), RouteFunc(resource.Index))
+	r.Get(prefix+resource.GetName()+"/:id", RouteFunc(resource.Get))
+	r.Post(prefix+resource.GetName(), RouteFunc(resource.Create))
+	r.Delete(prefix+resource.GetName()+"/:id", RouteFunc(resource.Delete))
+	r.Put(prefix+resource.GetName()+"/:id", RouteFunc(resource.Update))
 }
 
 // DefaultServer is an optional method to help get a preconfigured server

--- a/pkg/router/router_test.go
+++ b/pkg/router/router_test.go
@@ -11,9 +11,9 @@ func TestPathParam(t *testing.T) {
 		router := Router{}
 		var name string
 
-		router.Get("/:name", func(w http.ResponseWriter, r *http.Request) {
+		router.Get("/:name", http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 			name = router.PathParam(r, "name").(string)
-		})
+		}))
 
 		server := router.DefaultServer()
 		req := httptest.NewRequest(http.MethodGet, "/foo", nil)
@@ -32,9 +32,11 @@ func TestNestingRouters(t *testing.T) {
 
 		var name string
 
-		subrouter.Get("/:name", func(w http.ResponseWriter, r *http.Request) {
-			name = router.PathParam(r, "name").(string)
-		})
+		subrouter.Get("/:name", http.HandlerFunc(
+			func(w http.ResponseWriter, r *http.Request) {
+				name = router.PathParam(r, "name").(string)
+			},
+		))
 
 		router.Base("/v1").Merge(&subrouter)
 
@@ -53,10 +55,12 @@ func TestResponses(t *testing.T) {
 	t.Run("should handle GETs correctly", func(t *testing.T) {
 		router := Router{}
 
-		router.Get("/:name", func(w http.ResponseWriter, r *http.Request) {
-			w.WriteHeader(http.StatusTeapot)
-			w.Write([]byte("hello"))
-		})
+		router.Get("/:name", http.HandlerFunc(
+			func(w http.ResponseWriter, r *http.Request) {
+				w.WriteHeader(http.StatusTeapot)
+				w.Write([]byte("hello"))
+			},
+		))
 
 		server := router.DefaultServer()
 		req := httptest.NewRequest(http.MethodGet, "/foo", nil)
@@ -71,9 +75,9 @@ func TestResponses(t *testing.T) {
 		router := Router{}
 		var name string
 
-		router.Get("/:name", func(w http.ResponseWriter, r *http.Request) {
+		router.Get("/:name", http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 			name = r.Context().Value("name").(string)
-		})
+		}))
 
 		server := router.DefaultServer()
 		req := httptest.NewRequest(http.MethodGet, "/foo", nil)


### PR DESCRIPTION
Add support for controllers functioning with a normal "go flow". This
involves using the return interface{}, error pattern instead of working
directly with the response writer and the request.

BREAKING CHANGE: 🧨 Routers, controllers

This is a WIP